### PR TITLE
Include the drush alias

### DIFF
--- a/bde_env.drush.inc
+++ b/bde_env.drush.inc
@@ -66,12 +66,12 @@ function drush_bde_env_gen($filename = '') {
     }
   }
 
-  // Find the drush alias for that site
+  // Find the drush alias for that site.
   drush_sitealias_load_all();
   $alias_name = '';
   foreach (drush_get_context('site-aliases') as $name => $alias_values) {
-    if (!empty($alias_values['uri']) && ($base_url == $alias_values['uri'])) {
-      $alias_name = $name;
+    if (!empty($alias_values['uri']) && $base_url == $alias_values['uri']) {
+      $alias_name = substr($name, 1);
       break;
     }
   }

--- a/bde_env.drush.inc
+++ b/bde_env.drush.inc
@@ -65,6 +65,16 @@ function drush_bde_env_gen($filename = '') {
       $subcontext = realpath($subcontext);
     }
   }
+
+  // Find the drush alias for that site
+  drush_sitealias_load_all();
+  $alias_name = '';
+  foreach (drush_get_context('site-aliases') as $name => $alias_values) {
+    if (!empty($alias_values['uri']) && ($base_url == $alias_values['uri'])) {
+      $alias_name = $name;
+      break;
+    }
+  }
   
   $parameters = array(
     'extensions' => array(
@@ -74,6 +84,9 @@ function drush_bde_env_gen($filename = '') {
       'Drupal\DrupalExtension' => array(
         'drupal' => array(
           'drupal_root' => $site_root,
+        ),
+        'drush' => array(
+          'alias' => $alias_name,
         ),
         'subcontexts' => array(
           'paths' => $subcontexts,


### PR DESCRIPTION
The DrushContext which comes with the DrupalExtension requires the drush alias to be part of the settings, hence this PR includes that alias into the output if available.
