### PR TITLE
Include scheme if missing

### DIFF
--- a/bde_env.drush.inc
+++ b/bde_env.drush.inc
@@ -66,6 +66,10 @@ function drush_bde_env_gen($filename = '') {
     }
   }
   
+  if (strpos($base_url, '://') === FALSE) {
+    $base_url = 'http://' . $base_url;
+  }
+
   $parameters = array(
     'extensions' => array(
       'Behat\MinkExtension' => array(


### PR DESCRIPTION
In some cases, the scheme is missing in base_urls, e.g. if `drush beg` is called with an alias and if the uri in the alias definition is missing that leading scheme too. Just insert the default scheme if missing.
